### PR TITLE
Creates a secondary nav component

### DIFF
--- a/source/_patterns/components/secondary-navigation/secondary-nav.hbs
+++ b/source/_patterns/components/secondary-navigation/secondary-nav.hbs
@@ -1,0 +1,17 @@
+  <ul class="pf-secondary-nav" role="tablist">
+    <li class="pf-secondary-nav__item">
+      <a href="#" role="tab" class="pf-secondary-nav__link" aria-selected="true">Secondary Tab One</a>
+    </li>
+    <li class="pf-secondary-nav__item">
+      <a href="#" role="tab" class="pf-secondary-nav__link">Secondary Tab Two</a>
+    </li>
+    <li class="pf-secondary-nav__item">
+      <a href="#" role="tab" class="pf-secondary-nav__link">Secondary Tab Three</a>
+    </li>
+    <li class="pf-secondary-nav__item">
+      <a href="#" role="tab" class="pf-secondary-nav__link" aria-disabled="true">Secondary Tab Disabled</a>
+    </li>
+    <li class="pf-secondary-nav__item">
+      <a href="#" role="tab" class="pf-secondary-nav__link">Secondary Tab Five</a>
+    </li>
+  </ul>

--- a/source/_patterns/components/secondary-navigation/secondary-nav.md
+++ b/source/_patterns/components/secondary-navigation/secondary-nav.md
@@ -1,26 +1,30 @@
 ---
-title: Tabs
+title: PatternFly Secondary Navigation
 ---
 ## Overview
 
-See [Bootstrap tabs](http://v4-alpha.getbootstrap.com/components/navs/#tabs) for complete tabs documentation.
+The secondary navigation can be used on it's own but it's usually used with primary horizontal nav or tabs.
 
 ## Accessibility
-role="tabpanel" should be used for the div that wraps the tab contents.
-
-## Accessibility
+`role="tabpanel"` should be used for the div that wraps the tab contents.
+- `aria-selected="true"` should be added to the anchor that is active.
+- `aria-disabled="true"` should be added to the anchor that is disabled.
 
 | Attribute | Value | Usage |
 | -- | -- | -- |
 | `role` **Applied to:** `<nav>` | "navigation" |  **Outcome:** [Refer to this explanation for more details](http://a11yproject.com/posts/aria-landmark-roles/)   **Required:** Yes, until implicit mapping for `<nav>` is fully supported  |
 | `role` **Applied to:** `<ul>` | "tablist" |  **Outcome:** Identifies the `<ul>` list as a tablist to assistive device users   **Required:** Yes |
 | `role` **Applied to:** `<a>` | "tab" |  **Outcome:** Identifies the `<a>` link as a tab to assistive device users   **Required:** Yes |
-| `role` **Applied to:** `<div>` that wraps the tab contents | "tabpanel" |  **Outcome:** Identifies the tab contents to assistive device users   **Required:** Yes  **Note:** Examples on this page do not show tab contents. |
-| `aria-selected` **Applied to:** `li.active` | "true" |   **Outcome:** Communicates which page is selected to assistive device users   **Required:** Yes |
-
+| `role` **Applied to:** `<div>` that wraps the tab contents | "tabpanel" |  **Outcome:** Identifies the tab contents to assistive device users   **Required:** Yes  **Note:** And example of this is on the basic template |
+| `aria-selected` **Applied to:** `a` | "true" |   **Outcome:** Communicates which page is selected to assistive device users   **Required:** Yes |
+| `aria-disabled` **Applied to:** `a` | "true" |   **Outcome:** Communicates which page is disabled to assistive device users   **Required:** Yes |
 
 ## Usage
 
 | Class | Usage |
 | -- | -- |
-| `.pf-nav-tabs` **Applied to:** `ul` |  **Outcome:** Displays the menu in Patternfly secondary uderline style rather than the default square tab style **Required:** No **Remarks:** Always use it with `.nav` and `.nav-tabs`. |
+| `.pf-secondary-nav` **Applied to:** `ul` |  **Outcome:** Initiates a secondary underline style menu **Required:** Yes **Remarks:** Always use inside a `.nav` and `.nav-tabs` |
+| `.pf-secondary-nav__item` **Applied to:** `li` |  **Outcome:** This hook is here to future proof the component **Required:** No |
+| `.pf-secondary-nav__link` **Applied to:** `a` |  **Outcome:** Gives styles to anchors **Required:** Yes |
+| `aria-selected="true"` **Applied to:** `a` |  **Outcome:** Generates active state **Required:** No |
+| `aria-disabled="true"` **Applied to:** `a` |  **Outcome:** Generates disabled state **Required:** No |

--- a/source/_patterns/components/secondary-navigation/secondary-nav.md
+++ b/source/_patterns/components/secondary-navigation/secondary-nav.md
@@ -3,7 +3,7 @@ title: PatternFly Secondary Navigation
 ---
 ## Overview
 
-The secondary navigation can be used on it's own but it's usually used with primary horizontal nav or tabs.
+The secondary navigation can be used on it is own but it's usually used with primary horizontal nav or tabs.
 
 ## Accessibility
 `role="tabpanel"` should be used for the div that wraps the tab contents.

--- a/source/_patterns/components/secondary-navigation/secondary-nav.md
+++ b/source/_patterns/components/secondary-navigation/secondary-nav.md
@@ -1,0 +1,26 @@
+---
+title: Tabs
+---
+## Overview
+
+See [Bootstrap tabs](http://v4-alpha.getbootstrap.com/components/navs/#tabs) for complete tabs documentation.
+
+## Accessibility
+role="tabpanel" should be used for the div that wraps the tab contents.
+
+## Accessibility
+
+| Attribute | Value | Usage |
+| -- | -- | -- |
+| `role` **Applied to:** `<nav>` | "navigation" |  **Outcome:** [Refer to this explanation for more details](http://a11yproject.com/posts/aria-landmark-roles/)   **Required:** Yes, until implicit mapping for `<nav>` is fully supported  |
+| `role` **Applied to:** `<ul>` | "tablist" |  **Outcome:** Identifies the `<ul>` list as a tablist to assistive device users   **Required:** Yes |
+| `role` **Applied to:** `<a>` | "tab" |  **Outcome:** Identifies the `<a>` link as a tab to assistive device users   **Required:** Yes |
+| `role` **Applied to:** `<div>` that wraps the tab contents | "tabpanel" |  **Outcome:** Identifies the tab contents to assistive device users   **Required:** Yes  **Note:** Examples on this page do not show tab contents. |
+| `aria-selected` **Applied to:** `li.active` | "true" |   **Outcome:** Communicates which page is selected to assistive device users   **Required:** Yes |
+
+
+## Usage
+
+| Class | Usage |
+| -- | -- |
+| `.pf-nav-tabs` **Applied to:** `ul` |  **Outcome:** Displays the menu in Patternfly secondary uderline style rather than the default square tab style **Required:** No **Remarks:** Always use it with `.nav` and `.nav-tabs`. |

--- a/source/_patterns/components/tabs/tabs-patternfly.hbs
+++ b/source/_patterns/components/tabs/tabs-patternfly.hbs
@@ -1,8 +1,0 @@
-{{> components-tabs pfTabsAsPrimary="true"}}
-
-<!-- don't use the <br> they are here to create a space between the examples -->
-<br>
-<br>
-<!-- ===== -->
-
-{{> components-tabs pfTabsAsPrimary="true"  tabsDropdown="true" dropdownActive="true"}}

--- a/source/_patterns/components/tabs/tabs-secondary-width-dropdown.hbs
+++ b/source/_patterns/components/tabs/tabs-secondary-width-dropdown.hbs
@@ -1,8 +1,0 @@
-{{> components-tabs tabsSecondaryLevel="true" tabsSecondaryDropdown="true"}}
-
-<!-- don't use the <br> they are here to create a space between the examples -->
-<br>
-<br>
-<!-- ===== -->
-
-{{> components-tabs tabsSecondaryLevel="true" tabsSecondaryDropdown="true" tabsSecondaryDropdownActive="true"}}

--- a/source/_patterns/components/tabs/tabs-secondary.hbs
+++ b/source/_patterns/components/tabs/tabs-secondary.hbs
@@ -1,1 +1,0 @@
-{{> components-tabs tabsSecondaryLevel="true"}}

--- a/source/_patterns/components/tabs/tabs-single-level-with-dropdown.hbs
+++ b/source/_patterns/components/tabs/tabs-single-level-with-dropdown.hbs
@@ -5,4 +5,4 @@
 <br>
 <!-- ===== -->
 
-{{> components-tabs tabsDropdown="true" tabsDropdownActive="true"}}
+{{> components-tabs tabsDropdown="true" tabsDropdownActive="true" }}

--- a/source/_patterns/components/tabs/tabs.hbs
+++ b/source/_patterns/components/tabs/tabs.hbs
@@ -6,8 +6,8 @@ tabsSecondaryLevel - adds a secondary level menu
 tabstabsSecondaryDropdown - adds a dropdown tab to the secondary menu
 tabsSecondaryDropdownActive - shows the dropdown open if true
 --}}
-<nav role="navigation">
-  <ul class="nav nav-tabs {{#if pfTabsAsPrimary }}pf-nav-tabs{{/if }}" role="tablist">
+
+  <ul class="nav nav-tabs" role="tablist">
     <li class="nav-item" {{#unless tabsDropdown }}aria-selected="true"{{/unless }}><a href="#" role="tab" class="nav-link {{#unless tabsDropdown }}active{{/unless }}">Tab One</a></li>
     <li class="nav-item"><a href="#" role="tab" class="nav-link">Tab Two</a></li>
     <li class="nav-item"><a href="#" role="tab" class="nav-link">Tab Three</a></li>
@@ -35,33 +35,3 @@ tabsSecondaryDropdownActive - shows the dropdown open if true
   {{/if }}
 
   </ul>
-  {{#if tabsSecondaryLevel }}
-  <ul class="nav nav-tabs pf-nav-tabs" role="tablist">
-    <li class="nav-item" {{#unless tabsSecondaryDropdownActive }}aria-selected="true"{{/unless }}><a href="#" role="tab" class="nav-link {{#unless tabsSecondaryDropdownActive }}active{{/unless }}">Secondary Tab One</a></li>
-    <li class="nav-item"><a href="#" role="tab" class="nav-link">Secondary Tab Two</a></li>
-    <li class="nav-item"><a href="#" role="tab" class="nav-link">Secondary Tab Three</a></li>
-    <li class="nav-item"><a href="#" role="tab" class="nav-link disabled">Secondary Disabled</a></li>
-    <li class="nav-item"><a href="#" role="tab" class="nav-link">Secondary Tab Five</a></li>
-    {{#if tabsSecondaryDropdown }}
-      <li class="nav-item dropdown {{#if
-        tabsSecondaryDropdownActive }}show{{/if }}">
-        <a class="nav-link dropdown-toggle {{#if tabsSecondaryDropdownActive}} active {{/if }}"
-          role="button"
-          aria-haspopup="true"
-          aria-expanded="true"
-          data-toggle="dropdown"
-          href="#">
-          Secondary Menu Dropdown
-        </a>
-        <div class="dropdown-menu" role="menu">
-          <a class="dropdown-item">Action</a></a>
-          <a class="dropdown-item">Another action</a></a>
-          <a class="dropdown-item">Something else here</a></a>
-          <div class="dropdown-divider"></div>
-          <a class="dropdown-item">Separated link</a></a>
-        </div>
-      </li>
-    {{/if }}
-  </ul>
-  {{/if }}
-</nav>

--- a/source/_patterns/templates/basic-template.hbs
+++ b/source/_patterns/templates/basic-template.hbs
@@ -2,9 +2,10 @@
   <h1>Basic Page Title</h1>
   <p>This is a basic template with some of the elements that are avaliable on PatternFly 5 CSS</p>
 
-  {{> components-tabs tabsSecondaryLevel="true"
-  tabsSecondaryDropdown="true" }}
-
+  <nav role="navigation">
+    {{> components-tabs }}
+    {{> components-secondary-nav }}
+  </nav>
 
   <div class="row" role="tabpanel">
 

--- a/source/scss/_pf-nav.scss
+++ b/source/scss/_pf-nav.scss
@@ -40,47 +40,47 @@ limitations under the License.
   // }
 }
 
-// Patternfly-style tabs
-.pf-nav-tabs {
-
-  // .nav-item {
-  //   margin-bottom: 0;
-  // }
-  .nav-link {
-    border-width: 0 0 ($nav-tabs-border-width * 2) 0;
-    border-color: transparent;
-    margin: $pf-spacer-xs $pf-spacer-sm 0; // remove padding and add margin so that the underline is only beneath the text
-    padding: 0 0 $pf-spacer-xxxs 0;
-    font-size: $font-size-base;
-
-    @include hover-focus-active {
-      border-color: $nav-tabs-active-link-hover-border-color;
-    }
-
-    &.active {
-      border-color: $nav-tabs-active-link-hover-color;
-      @include hover-focus-active {
-        border-color: $nav-tabs-active-link-hover-color;
-      }
-    }
-  }
-
-  .dropdown-menu {
-    margin-top: 0;
-    margin-left: $pf-spacer-sm;
-  }
-
-  .nav-link.active,
-  .nav-item.show .nav-link {
-    color: $nav-tabs-active-link-hover-color;
-    background-color:inherit;
-    border-color: inherit;
-  }
-
-// if Patternfly-style tabs are used as a secondary menu to another .nav-tabs
-  .nav-tabs + & {
-    .nav-link {
-      padding-bottom: $pf-spacer-xxxs;
-    }
-  }
-}
+// // Patternfly-style tabs
+// .pf-nav-tabs {
+//
+//   // .nav-item {
+//   //   margin-bottom: 0;
+//   // }
+//   .nav-link {
+//     border-width: 0 0 ($nav-tabs-border-width * 2) 0;
+//     border-color: transparent;
+//     margin: $pf-spacer-xs $pf-spacer-sm 0; // remove padding and add margin so that the underline is only beneath the text
+//     padding: 0 0 $pf-spacer-xxxs 0;
+//     font-size: $font-size-base;
+//
+//     @include hover-focus-active {
+//       border-color: $nav-tabs-active-link-hover-border-color;
+//     }
+//
+//     &.active {
+//       border-color: $nav-tabs-active-link-hover-color;
+//       @include hover-focus-active {
+//         border-color: $nav-tabs-active-link-hover-color;
+//       }
+//     }
+//   }
+//
+//   .dropdown-menu {
+//     margin-top: 0;
+//     margin-left: $pf-spacer-sm;
+//   }
+//
+//   .nav-link.active,
+//   .nav-item.show .nav-link {
+//     color: $nav-tabs-active-link-hover-color;
+//     background-color:inherit;
+//     border-color: inherit;
+//   }
+//
+// // if Patternfly-style tabs are used as a secondary menu to another .nav-tabs
+//   .nav-tabs + & {
+//     .nav-link {
+//       padding-bottom: $pf-spacer-xxxs;
+//     }
+//   }
+// }

--- a/source/scss/_pf-secondary-nav.scss
+++ b/source/scss/_pf-secondary-nav.scss
@@ -20,7 +20,7 @@ limitations under the License.
 .pf-secondary-nav {
   @include list-unstyled;
   display: flex;
-  // The background creates a the border under the menu
+  // The background creates a border under the menu
   background-image:
     linear-gradient(
       to top,
@@ -39,8 +39,6 @@ limitations under the License.
   }
 }
 
-
-
 .pf-secondary-nav__link {
   @include hover-focus-active {
     color: inherit;
@@ -53,7 +51,6 @@ limitations under the License.
     );
     text-decoration: inherit;
   }
-
   display: inline-flex;
   align-items: center;
   padding-top: $pf-secondary-nav-link-padding;
@@ -82,14 +79,13 @@ limitations under the License.
     );
   }
 
-
   // .pf-secondary-nav__link[aria-disabled="true"]
   &[aria-disabled="true"] {
-    color: $pf-secondary-nav-link-disabled-color;
-    cursor: not-allowed;
     @include hover-focus-active {
       // The background removes the border when hover on disabled state
       background-image: none;
     }
+    color: $pf-secondary-nav-link-disabled-color;
+    cursor: not-allowed;
   }
 }

--- a/source/scss/_pf-secondary-nav.scss
+++ b/source/scss/_pf-secondary-nav.scss
@@ -1,0 +1,95 @@
+/*
+Copyright 2016 Red Hat, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//
+// PatternFly Seconary Tabs
+// --------------------------------------------------
+
+.pf-secondary-nav {
+  @include list-unstyled;
+  display: flex;
+  // The background creates a the border under the menu
+  background-image:
+    linear-gradient(
+      to top,
+      $pf-secondary-nav-border-color $pf-secondary-nav-border-width,
+      transparent $pf-secondary-nav-border-width
+  );
+
+  // Selects every direct child of pf-secondary-nav, for example .pf-secondary-nav__item
+  > * {
+    display: flex;
+    margin-left: $pf-secondary-nav-item-margin;
+    margin-right: $pf-secondary-nav-item-margin;
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+
+
+
+.pf-secondary-nav__link {
+  @include hover-focus-active {
+    color: inherit;
+    // The background creates a thicker border under the link
+    background-image:
+    linear-gradient(
+    to top,
+    $nav-tabs-active-link-hover-border-color ($pf-secondary-nav-border-width * 2),
+    transparent ($pf-secondary-nav-border-width * 2)
+    );
+    text-decoration: inherit;
+  }
+
+  display: inline-flex;
+  align-items: center;
+  padding-top: $pf-secondary-nav-link-padding;
+  padding-bottom: $pf-secondary-nav-link-padding;
+  color: $pf-secondary-nav-color;
+
+  // When https://patternfly.atlassian.net/browse/PTNFLY-2471 is DONE update this to `&[aria-current="true" i]` We need the i flag because aria selector is case sensitive.
+  // .pf-secondary-nav__link[aria-selected="true"]
+  &[aria-selected="true"] {
+    @include hover-focus-active {
+      // The background creates a thicker blue border under the active link
+      background-image:
+      linear-gradient(
+      to top,
+      $pf-secondary-nav-link-active-color ($pf-secondary-nav-border-width * 2),
+      transparent ($pf-secondary-nav-border-width * 2)
+      );
+    }
+    color: $pf-secondary-nav-link-active-color;
+    // The background creates a thicker blue border under the active link
+    background-image:
+    linear-gradient(
+    to top,
+    $pf-secondary-nav-link-active-border-color ($pf-secondary-nav-border-width * 2),
+    transparent ($pf-secondary-nav-border-width * 2)
+    );
+  }
+
+
+  // .pf-secondary-nav__link[aria-disabled="true"]
+  &[aria-disabled="true"] {
+    color: $pf-secondary-nav-link-disabled-color;
+    cursor: not-allowed;
+    @include hover-focus-active {
+      // The background removes the border when hover on disabled state
+      background-image: none;
+    }
+  }
+}

--- a/source/scss/_pf-variables.scss
+++ b/source/scss/_pf-variables.scss
@@ -303,6 +303,7 @@ $spacers: (
     y: $pf-spacer-xxxxl
   )
 );
+
 $border-width: 1px !default;
 
 
@@ -627,6 +628,23 @@ $dropdown-link-hover-bg:         $pf-component-hover-bg !default;
 $dropdown-item-padding-x:        $pf-spacer-lg !default;
 
 // $dropdown-header-color:          $gray-light !default;
+
+
+
+// Patternfly Secondary Navigation
+
+
+$pf-secondary-nav-color:                     $gray !default;
+
+$pf-secondary-nav-border-color:              $pf-component-border-color !default;
+$pf-secondary-nav-border-width:              $border-width !default;
+
+$pf-secondary-nav-item-margin:               $pf-spacer-sm !default;
+
+$pf-secondary-nav-link-padding:              $pf-spacer-xxs !default;
+$pf-secondary-nav-link-active-border-color:  $link-color !default;
+$pf-secondary-nav-link-active-color:         $link-color !default;
+$pf-secondary-nav-link-disabled-color:       $gray-light !default;
 
 
 

--- a/source/scss/patternfly.scss
+++ b/source/scss/patternfly.scss
@@ -60,6 +60,7 @@ limitations under the License.
 @import "node_modules/bootstrap/scss/nav";
 @import "pf-nav";
 @import "node_modules/bootstrap/scss/navbar";
+@import "pf-secondary-nav";
 @import "node_modules/bootstrap/scss/card";
 @import "pf-card";
 @import "node_modules/bootstrap/scss/breadcrumb";


### PR DESCRIPTION
@jgiardino @srambach I've created a secondary nav component and removes the pfnav extension of boostrap, let's talk about it during the meeting today

You can preview it here:
http://blog.andresgalante.com/patternfly-atomic/?p=viewall-components-secondary-navigation

And this is how it interacts with bs tabs:
http://blog.andresgalante.com/patternfly-atomic/?p=templates-basic-template
